### PR TITLE
Linux osg 370

### DIFF
--- a/src/osgb.rs
+++ b/src/osgb.rs
@@ -211,7 +211,7 @@ pub fn osgb_batch_convert(
                 },
                 "geometricError": 1000,
                 "content": {
-                    "uri" : format!("{}/tileset.json", path.replace(&out_dir,".").replace("\\","/"))
+                    "uri" : format!("{}/tileset.json", path.replace(&out_dir,"./")//.replace("\\","/"))
                 }
             }
         );

--- a/src/osgb.rs
+++ b/src/osgb.rs
@@ -211,7 +211,7 @@ pub fn osgb_batch_convert(
                 },
                 "geometricError": 1000,
                 "content": {
-                    "uri" : format!("{}/tileset.json", path.replace(&out_dir,"./")//.replace("\\","/"))
+                    "uri" : format!("{}/tileset.json", path.replace(&out_dir,"./"))//.replace("\\","/"))
                 }
             }
         );


### PR DESCRIPTION
linux下生成的tileset.json中，
uri类似于 ".Data/xxxx/tileset.json"的格式，不正确。
做了适应Linux的Path分隔符的修改