### PR TITLE
修复 GeoTransform.h 中的条件编译指令，添加 MacOS 支持，更新编译说明

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rayon = "1.0"
 # serilaze
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde-xml-rs = "0.2.1"
+serde-xml-rs = "0.4"
 
 # log
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ git clone https://github.com/microsoft/vcpkg.git
 ./vcpkg/vcpkg install gdal:x64-windows-release
 cargo build --release
 ```
+## MacOS
+```
+#install brew first
+brew install rust gdal open-scene-graph
+git clone https://github.com/fanvanzh/3dtiles
+cd 3dtiles
+cargo build --release
+```
 # 使用说明
 
 ## ① 命令行格式

--- a/build.rs
+++ b/build.rs
@@ -55,11 +55,44 @@ fn build_linux_unkonw() {
     println!("cargo:rustc-link-lib=gdal");
 }
 
+fn build_macos() {
+    cc::Build::new()
+        .cpp(true)
+        .flag("-std=c++11")
+        .flag("-Wno-deprecated-declarations")
+        .warnings(false)
+        .include("./src")
+        .include("/opt/homebrew/include")  // Homebrew include path for M1 Mac
+        .include("/opt/homebrew/opt/gdal/include")  // GDAL include path
+        .include("/opt/homebrew/opt/open-scene-graph/include")  // OSG include path
+        .file("./src/tileset.cpp")
+        .file("./src/shp23dtile.cpp")
+        .file("./src/osgb23dtile.cpp")
+        .file("./src/dxt_img.cpp")
+        .file("./src/GeoTransform.cpp")
+        .compile("_3dtile");
+    
+    // Link search paths
+    println!("cargo:rustc-link-search=native=/opt/homebrew/lib");
+    println!("cargo:rustc-link-search=native=/opt/homebrew/opt/gdal/lib");
+    println!("cargo:rustc-link-search=native=/opt/homebrew/opt/open-scene-graph/lib");
+    
+    // OSG libraries
+    println!("cargo:rustc-link-lib=osg");
+    println!("cargo:rustc-link-lib=osgDB");
+    println!("cargo:rustc-link-lib=osgUtil");
+    println!("cargo:rustc-link-lib=OpenThreads");
+    
+    // GDAL library
+    println!("cargo:rustc-link-lib=gdal");
+}
+
 fn main() {
     match env::var("TARGET") {
         Ok(val) => match val.as_str() {
             "x86_64-unknown-linux-gnu" => build_linux_unkonw(),
             "x86_64-pc-windows-msvc" => build_win_msvc(),
+            "aarch64-apple-darwin" => build_macos(),
             &_ => {}
         },
         _ => {}

--- a/src/GeoTransform.h
+++ b/src/GeoTransform.h
@@ -3,6 +3,9 @@
 #ifdef _WIN32
     #include <ogr_spatialref.h>
     #include <ogrsf_frmts.h>
+#elif __APPLE__ 
+    #include <ogr_spatialref.h>
+    #include <ogrsf_frmts.h>
 #else
     #include <gdal/ogr_spatialref.h>
     #include <gdal/ogrsf_frmts.h>

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,7 @@ fn convert_osgb(src: &str, dest: &str, config: &str) {
             if let Ok(_) = f.read_to_string(&mut buffer) {
                 //
                 if let Ok(metadata) =
-                    serde_xml_rs::deserialize::<_, ModelMetadata>(buffer.as_bytes())
+                    serde_xml_rs::from_str::<ModelMetadata>(&buffer)
                 {
                     //println!("{:?}", metadata);
                     let v: Vec<&str> = metadata.SRS.split(":").collect();

--- a/src/shp23dtile.cpp
+++ b/src/shp23dtile.cpp
@@ -6,6 +6,8 @@
 /* vcpkg path */
 #ifdef _WIN32
     #include <ogrsf_frmts.h>
+#elif __APPLE__
+    #include <ogrsf_frmts.h>
 #else
     #include <gdal/ogrsf_frmts.h>
 #endif

--- a/src/tileset.cpp
+++ b/src/tileset.cpp
@@ -8,6 +8,9 @@
 #ifdef _WIN32
     #include <ogr_spatialref.h>
     #include <ogrsf_frmts.h>
+#elif __APPLE__
+    #include <ogr_spatialref.h>
+    #include <ogrsf_frmts.h>
 #else
     #include <gdal/ogrsf_frmts.h>
     #include <gdal/ogr_spatialref.h>


### PR DESCRIPTION
更新库依赖serde-xml-rs 至 0.4，同时修改`main.rs`中对应函数

增加`build.rs`中增加 Apple silicon macOS(`aarch64-apple-darwin`)编译配置

为 macOS 环境适配头文件
