### PR TITLE
修复了一些已知问题

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,9 @@
 name: Ubuntu
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -16,6 +19,6 @@ jobs:
 
     - name: Build
       run: cargo build --verbose --release
-    
+
     - name: Test
       run: cargo test --verbose

--- a/.github/workflows/macOS-arm64.yml
+++ b/.github/workflows/macOS-arm64.yml
@@ -1,0 +1,31 @@
+name: macOS
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build-and-test:
+    runs-on: macos-15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@main
+
+    - name: Install dependencies on macOS
+      run: |
+        brew install gdal open-scene-graph
+
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Build
+      run: cargo build --verbose --release
+
+    - name: Test
+      run: cargo test --verbose

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,9 @@
 name: Windows
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build-and-test:
     runs-on: windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,10 +17,15 @@ jobs:
 
     - name: Debug paths
       run: |
-        echo "GITHUB_WORKSPACE=${{ github.workspace }}"
-        echo "VCPKG_ROOT=${{ env.VCPKG_ROOT }}"
-        echo "WORKDIR=$(pwd)"
-        dir "%VCPKG_ROOT%"
+        echo GITHUB_WORKSPACE=${{ github.workspace }}
+        echo VCPKG_ROOT=%VCPKG_ROOT%
+        echo WORKDIR=%CD%
+        if exist "%VCPKG_ROOT%" (
+          echo "VCPKG_ROOT exists, listing:"
+          dir "%VCPKG_ROOT%" /b
+        ) else (
+          echo "VCPKG_ROOT not found (expected on first run)"
+        )
       shell: cmd
 
     - name: Cache vcpkg artifacts
@@ -32,6 +37,7 @@ jobs:
           ${{ env.VCPKG_ROOT }}\packages
           ${{ env.VCPKG_ROOT }}\downloads
           ${{ github.workspace }}\vcpkg_installed
+        # if you don't have vcpkg.json, replace hashFiles(...) with a fixed token
         key: ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
           ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-
@@ -39,7 +45,6 @@ jobs:
 
     - name: Show cache result & inspect installed
       run: |
-        echo cache-hit=%CACHE_HIT%
         echo "cache-hit(official)=${{ steps.cache-vcpkg.outputs.cache-hit }}"
         if exist "%VCPKG_ROOT%\installed\%VCPKG_TRIPLET%" (
           echo "Installed dir contents:"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,18 +11,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set VCPKG_ROOT
+      run: echo "VCPKG_ROOT=${{ github.workspace }}\\vcpkg" >> $env:GITHUB_ENV
+
     # 缓存 vcpkg 已安装包 & 构建产物
     - name: Cache vcpkg artifacts
       uses: actions/cache@v4
       id: cache-vcpkg
       with:
         path: |
-          ${{ env.VCPKG_ROOT }}
           ${{ github.workspace }}/vcpkg_installed
-          !${{ env.VCPKG_ROOT }}/.git
-          !${{ env.VCPKG_ROOT }}/buildtrees
-          !${{ env.VCPKG_ROOT }}/packages
-          !${{ env.VCPKG_ROOT }}/downloads
+          ${{ github.workspace }}/vcpkg
         key: ${{ runner.os }}-vcpkg-${{ hashFiles('**/build.rs') }}
         restore-keys: |
           ${{ runner.os }}-vcpkg-
@@ -32,12 +31,6 @@ jobs:
       run: |
         git clone https://github.com/microsoft/vcpkg.git
         ./vcpkg/bootstrap-vcpkg.bat
-        ./vcpkg/vcpkg install gdal:x64-windows-release
-        ./vcpkg/vcpkg install osg:x64-windows-release
-        tree ./vcpkg/installed /F /A
-
-    - name: Set VCPKG_ROOT
-      run: echo "VCPKG_ROOT=${{ github.workspace }}\\vcpkg" >> $env:GITHUB_ENV
 
     - name: Build
-      run: cargo build --verbose --release
+      run: cargo build -vv --release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,21 +20,40 @@ jobs:
         echo "GITHUB_WORKSPACE=${{ github.workspace }}"
         echo "VCPKG_ROOT=${{ env.VCPKG_ROOT }}"
         echo "WORKDIR=$(pwd)"
-        dir
+        dir "%VCPKG_ROOT%"
       shell: cmd
 
-    # 缓存 vcpkg 工具与 repo 下的 vcpkg_installed（表达式在模板展开时可用）
     - name: Cache vcpkg artifacts
       uses: actions/cache@v4
       id: cache-vcpkg
       with:
         path: |
-          ${{ env.VCPKG_ROOT }}
+          ${{ env.VCPKG_ROOT }}\installed\${{ env.VCPKG_TRIPLET }}
+          ${{ env.VCPKG_ROOT }}\packages
+          ${{ env.VCPKG_ROOT }}\downloads
           ${{ github.workspace }}\vcpkg_installed
         key: ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
           ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-
           ${{ runner.os }}-vcpkg-
+
+    - name: Show cache result & inspect installed
+      run: |
+        echo cache-hit=%CACHE_HIT%
+        echo "cache-hit(official)=${{ steps.cache-vcpkg.outputs.cache-hit }}"
+        if exist "%VCPKG_ROOT%\installed\%VCPKG_TRIPLET%" (
+          echo "Installed dir contents:"
+          dir "%VCPKG_ROOT%\installed\%VCPKG_TRIPLET%" /b
+        ) else (
+          echo "No installed dir at %VCPKG_ROOT%\installed\%VCPKG_TRIPLET%"
+        )
+        if exist "%GITHUB_WORKSPACE%\vcpkg_installed" (
+          echo "repo vcpkg_installed contents:"
+          dir "%GITHUB_WORKSPACE%\vcpkg_installed" /b
+        ) else (
+          echo "No repo vcpkg_installed at %GITHUB_WORKSPACE%\vcpkg_installed"
+        )
+      shell: cmd
 
     - name: Install dependencies on Windows
       if: steps.cache-vcpkg.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,11 +11,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache dependencies
+    # 缓存 vcpkg 已安装包 & 构建产物
+    - name: Cache vcpkg artifacts
       uses: actions/cache@v4
       id: cache-vcpkg
       with:
-        path: ./vcpkg
+        path: |
+          ${{ env.VCPKG_ROOT }}
+          ${{ github.workspace }}/vcpkg_installed
+          !${{ env.VCPKG_ROOT }}/.git
+          !${{ env.VCPKG_ROOT }}/buildtrees
+          !${{ env.VCPKG_ROOT }}/packages
+          !${{ env.VCPKG_ROOT }}/downloads
         key: ${{ runner.os }}-vcpkg-${{ hashFiles('**/build.rs') }}
         restore-keys: |
           ${{ runner.os }}-vcpkg-
@@ -28,6 +35,9 @@ jobs:
         ./vcpkg/vcpkg install gdal:x64-windows-release
         ./vcpkg/vcpkg install osg:x64-windows-release
         tree ./vcpkg/installed /F /A
+
+    - name: Set VCPKG_ROOT
+      run: echo "VCPKG_ROOT=${{ github.workspace }}\\vcpkg" >> $env:GITHUB_ENV
 
     - name: Build
       run: cargo build --verbose --release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/vcpkg_installed/
+/.vscode/compile_commands.json
+/compile_commands.json
+/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode/compile_commands.json
 /compile_commands.json
 /.cache/
+/build/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,9 @@
+{
+  "configurations": [
+    {
+      "name": "compile_commands.json",
+      "compileCommands": "./build/compile_commands.json"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,69 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug (Linux, gdb)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/_3dtile",
+      "args": ["-f", "osgb", "-i", "/path/to/osgb/dir", "-o", "/path/to/output/dir"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "cargo build",
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "sourceLanguages": ["rust", "cpp"]
+    },
+    {
+      "name": "Debug SHP (Linux, gdb)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/_3dtile",
+      "args": ["-f", "shape", "-i", "/path/to/osgb/dir", "-o", "/path/to/output/dir", "--height", "height"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "cargo build",
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "sourceLanguages": ["rust", "cpp"]
+    },
+    {
+      "name": "Debug (macOS, lldb)",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/_3dtile",
+      "args": ["-f", "osgb", "-i", "/path/to/osgb/dir", "-o", "/path/to/output/dir"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "cargo build",
+      "sourceLanguages": ["rust", "cpp"]
+    },
+    {
+      "name": "Debug SHP (macOS, lldb)",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/_3dtile",
+      "args": ["-f", "shape", "-i", "/Users/wallance/Desktop/1758464001_building/1758464001_building.shp", "-o", "/Users/wallance/Desktop/test-output-shapefile", "--height", "HEIGHT"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "cargo build",
+      "sourceLanguages": ["rust", "cpp"]
+    },
+    {
+      "name": "Debug (Windows, MSVC)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}\\target\\debug\\_3dtile.exe",
+      "args": ["-f", "osgb", "-i", "/path/to/osgb/dir", "-o", "/path/to/output/dir"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "cargo build",
+      "sourceLanguages": ["rust", "cpp"]
+    },
+    {
+      "name": "Debug SHP (Windows, MSVC)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}\\target\\debug\\_3dtile.exe",
+      "args": ["-f", "shape", "-i", "/path/to/osgb/dir", "-o", "/path/to/output/dir", "--height", "HEIGHT"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "cargo build",
+      "sourceLanguages": ["rust", "cpp"]
+    },
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "cargo build",          // 👈 这里必须和 launch.json 里的一致
+      "type": "shell",
+      "command": "cargo",
+      "args": ["build"],               // 如果你要调试 release，可以写 ["build", "--release"]
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": ["$rustc"]
+    }
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,25 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.22)
 PROJECT(3dtiles)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(APPLE)
     # 在 macOS 或其他 Apple 系统下
     add_compile_options(-Wno-error=unguarded-availability-new)
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 file(GLOB_RECURSE SOURCES src/*.cpp)
 file(GLOB_RECURSE HEADERS src/*.h src/json.hpp)
 add_library(_3dtile STATIC ${SOURCES})
 target_include_directories(_3dtile PUBLIC src)
+
+if (WIN32)
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}scripts/buildsystems/vcpkg.cmake")
+    set(VCPKG_TARGET_TRIPLET "x64-windows-release")
+
+    target_compile_definitions(_3dtile PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+    target_precompile_headers(_3dtile PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/osg_fix.h")
+endif()
 
 find_package(GDAL CONFIG REQUIRED)
 if (GDAL_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,11 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.22)
 PROJECT(3dtiles)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_compile_options(-Wno-error=unguarded-availability-new)
+
+if(APPLE)
+    # 在 macOS 或其他 Apple 系统下
+    add_compile_options(-Wno-error=unguarded-availability-new)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.22)
+
+PROJECT(3dtiles)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-Wno-error=unguarded-availability-new)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+file(GLOB_RECURSE SOURCES src/*.cpp)
+file(GLOB_RECURSE HEADERS src/*.h src/json.hpp)
+add_library(_3dtile STATIC ${SOURCES})
+target_include_directories(_3dtile PUBLIC src)
+
+find_package(GDAL CONFIG REQUIRED)
+if (GDAL_FOUND)
+    message(STATUS "GDAL found: ${GDAL_VERSION}, include dirs: ${GDAL_INCLUDE_DIRS}, libraries: ${GDAL_LIBRARIES}")
+    target_link_libraries(_3dtile PRIVATE GDAL::GDAL)
+    target_include_directories(_3dtile PUBLIC ${GDAL_INCLUDE_DIRS})
+endif()
+
+
+set(osg_OPENGL_PROFILE GL3)
+find_package(OpenSceneGraph 3.6.5 REQUIRED COMPONENTS osgDB osgUtil osgViewer OpenThreads)
+if (OpenSceneGraph_FOUND)
+    message(STATUS "OpenSceneGraph include dirs: ${OSG_INCLUDE_DIR}, libraries: ${OSG_LIBRARIES}")
+    target_link_libraries(_3dtile PRIVATE osgDB osgUtil osgViewer OpenThreads)
+    target_include_directories(_3dtile PUBLIC ${OSG_INCLUDE_DIR})
+endif()
+
+install(TARGETS _3dtile DESTINATION lib)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ env_logger = "0.5"
 
 byteorder = "1.2"
 [build-dependencies]
-cc = "1.0.*"
+cmake = "0.1"
+pkg-config = "0.3"

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ git clone https://github.com/fanvanzh/3dtiles.git
 cd 3dtiles
 git clone https://github.com/microsoft/vcpkg.git
 .\vcpkg\bootstrap-vcpkg.bat
-.\vcpkg\vcpkg install osg:x64-windows-release
-.\vcpkg\vcpkg install gdal:x64-windows-release
 cargo build --release
 ```
 # Usage
@@ -126,8 +124,6 @@ git clone https://github.com/fanvanzh/3dtiles.git
 cd 3dtiles
 git clone https://github.com/microsoft/vcpkg.git
 .\vcpkg\bootstrap-vcpkg.bat
-.\vcpkg\vcpkg install osg:x64-windows-release
-.\vcpkg\vcpkg install gdal:x64-windows-release
 cargo build --release
 ```
 ## MacOS

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**English | [简体中文](#简介)** 
+**English | [简体中文](#简介)**
 
 # Introduction
 
@@ -12,7 +12,7 @@
 
 - `Esri Shapefile` to `3D-Tiles`: convert shapefile to 3D-Tiles.
 
-You may intereted in: 
+You may intereted in:
 
 - [How to build?](https://github.com/fanvanzh/3dtiles/wiki/How-to-build)
 
@@ -95,6 +95,9 @@ _3dtile.exe -f b3dm -i E:\Data\aa.b3dm -o E:\Data\aa.glb
 - `Osgb(OpenSceneGraph Binary)` 转 `3D-Tiles`
 
 - `Esri Shapefile` 转 `3D-Tiles`
+
+# 生成compile_commands.json便于vscode索引C++头文件
+cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 # 编译
 ## Ubuntu

--- a/build.rs
+++ b/build.rs
@@ -30,8 +30,8 @@ fn build_win_msvc() {
 
 fn build_linux_unkown() {
     // Probe Library Link for GDAL and OpenSceneGraph
-    pkg_config::Config::new().atleast_version("3.9.3").probe("gdal").unwrap();
-    pkg_config::Config::new().atleast_version("3.6.5").probe("OpenSceneGraph").unwrap();
+    pkg_config::Config::new().atleast_version("3.8.4").probe("gdal").unwrap();
+    pkg_config::Config::new().probe("openscenegraph").unwrap();
     let dst = Config::new(".").very_verbose(true).build();
     // for FFI C++ static library
     println!("cargo:rustc-link-lib=static=_3dtile");
@@ -46,13 +46,14 @@ fn build_linux_unkown() {
     // gdal library
     println!("cargo:rustc-link-lib=gdal");
 
-    copy_gdal_data("/usr/lib/x86_64-linux-gnu/share/");
-    copy_proj_data("/usr/lib/x86_64-linux-gnu/share/");
+    // for ubuntu 22.04 using apt install libgdal-dev
+    copy_gdal_data("/usr/share/");
+    copy_proj_data("/usr/share/");
 }
 
 fn build_macos() {
     // Probe Library Link for GDAL and OpenSceneGraph
-    pkg_config::Config::new().atleast_version("3.9.3").probe("gdal").unwrap();
+    pkg_config::Config::new().atleast_version("3.8.4").probe("gdal").unwrap();
     pkg_config::Config::new().atleast_version("3.6.5").probe("OpenSceneGraph").unwrap();
     // Get VCPKG_ROOT environment variable
     let dst = Config::new(".").very_verbose(true).build();

--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,9 @@ fn build_linux_unkown() {
     pkg_config::Config::new().atleast_version("3.8.4").probe("gdal").unwrap();
     pkg_config::Config::new().probe("openscenegraph").unwrap();
     let dst = Config::new(".").very_verbose(true).build();
+    println!("cmake dst = {}", dst.display());
+    // Link Search Path for C++ Implementation
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
     // for FFI C++ static library
     println!("cargo:rustc-link-lib=static=_3dtile");
     // -------------
@@ -45,6 +48,8 @@ fn build_linux_unkown() {
     println!("cargo:rustc-link-lib=OpenThreads");
     // gdal library
     println!("cargo:rustc-link-lib=gdal");
+    // Link Standard C++
+    println!("cargo:rustc-link-lib=stdc++");
 
     // for ubuntu 22.04 using apt install libgdal-dev
     copy_gdal_data("/usr/share/");
@@ -75,7 +80,7 @@ fn build_macos() {
 
     // GDAL library
     println!("cargo:rustc-link-lib=gdal");
-    // Link Search Path for C++ Implementation
+    // Link Standard C++
     println!("cargo:rustc-link-lib=c++");
     copy_gdal_data("/opt/homebrew/opt/gdal/share/");
     copy_proj_data("/opt/homebrew/opt/proj/share/");

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,7 @@ fn convert_gltf(src: &str, dest: &str) {
     }
 }
 
+#[allow(dead_code)]
 #[allow(non_snake_case)]
 #[derive(Debug, Deserialize)]
 struct ModelMetadata {

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ fn convert_gltf(src: &str, dest: &str) {
 #[allow(non_snake_case)]
 #[derive(Debug, Deserialize)]
 struct ModelMetadata {
-    pub _version: String,
+    pub version: String,
     pub SRS: String,
     pub SRSOrigin: String,
 }
@@ -272,16 +272,29 @@ fn convert_osgb(src: &str, dest: &str, config: &str) {
                                         Path::new(&exe_dir)
                                             .parent()
                                             .unwrap()
-                                            .join("gdal_data")
+                                            .join("gdal")
+                                            .to_str()
+                                            .unwrap()
+                                            .into()
+                                    };
+                                    let proj_lib: String = {
+                                        use std::path::Path;
+                                        let exe_dir = ::std::env::current_exe().unwrap();
+                                        Path::new(&exe_dir)
+                                            .parent()
+                                            .unwrap()
+                                            .join("proj")
                                             .to_str()
                                             .unwrap()
                                             .into()
                                     };
                                     unsafe {
                                         use std::ffi::CString;
-                                        let c_str = CString::new(gdal_data).unwrap();
-                                        let ptr = c_str.as_ptr();
-                                        if osgb::epsg_convert(srs, pt.as_mut_ptr(), ptr) {
+                                        let gdal_c_str = CString::new(gdal_data).unwrap();
+                                        let gdal_ptr = gdal_c_str.as_ptr();
+                                        let proj_c_str = CString::new(proj_lib).unwrap();
+                                        let proj_ptr = proj_c_str.as_ptr();
+                                        if osgb::epsg_convert(srs, pt.as_mut_ptr(), gdal_ptr, proj_ptr) {
                                             center_x = pt[0];
                                             center_y = pt[1];
                                             info!("epsg: x->{}, y->{}", pt[0], pt[1]);

--- a/src/osg_fix.h
+++ b/src/osg_fix.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef _WIN32
+
+  // 在包含 windows.h 之前定义这些，让 windows.h 更精简并避免 min/max 宏污染
+  #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+  #endif
+
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+
+  #include <windows.h>
+
+  #ifndef WINGDIAPI
+    #define WINGDIAPI __declspec(dllimport)
+  #endif
+
+#endif

--- a/src/osgb.rs
+++ b/src/osgb.rs
@@ -24,10 +24,10 @@ extern "C" {
     ) -> *mut libc::c_void;
 
     pub fn osgb2glb(name_in: *const u8, name_out: *const u8) -> bool;
- 
+
 	fn transform_c(radian_x: f64, radian_y: f64, height_min: f64, ptr: *mut f64);
 
-    pub fn epsg_convert(insrs: i32, val: *mut f64, gdal: *const i8) -> bool;
+    pub fn epsg_convert(insrs: i32, val: *mut f64, gdal: *const i8, proj: *const i8) -> bool;
 
     pub fn wkt_convert(gdal: *const u8, val: *mut f64, gdal: *const i8) -> bool;
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -32,9 +32,9 @@ fn walk_path(dir: &Path, cb: &mut dyn FnMut(&str)) -> io::Result<()> {
 
 pub fn shape_batch_convert(from: &str, to: &str, height: &str) -> bool {
     unsafe {
-        let mut source_vec = CString::new(from).unwrap();
-        let mut dest_vec = CString::new(to).unwrap();
-        let mut height_vec = CString::new(height).unwrap();
+        let source_vec = CString::new(from).unwrap();
+        let dest_vec = CString::new(to).unwrap();
+        let height_vec = CString::new(height).unwrap();
         let res = shp23dtile(
             source_vec.as_ptr() as *const u8,
             0,

--- a/src/tileset.cpp
+++ b/src/tileset.cpp
@@ -23,12 +23,23 @@
 static const double pi = std::acos(-1);
 
 extern "C" bool
-epsg_convert(int insrs, double* val, char* path) {
-    CPLSetConfigOption("GDAL_DATA", path);
+epsg_convert(int insrs, double* val, char* gdal_data, char *proj_lib) {
+    CPLSetConfigOption("GDAL_DATA", gdal_data);
+    CPLSetConfigOption("PROJ_LIB", proj_lib);
     OGRSpatialReference inRs,outRs;
-    inRs.importFromEPSG(insrs);
-    outRs.importFromEPSG(4326);
-    OGRCoordinateTransformation *poCT = OGRCreateCoordinateTransformation( &inRs, &outRs );
+    OGRErr inErr = inRs.importFromEPSG(insrs);
+    if (inErr != OGRERR_NONE) {
+        LOG_E("importFromEPSG(%d) failed, err_code=%d", insrs, inErr);
+        return false;
+    }
+    inRs.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    OGRErr outErr = outRs.importFromEPSG(4326);
+    if (outErr != OGRERR_NONE) {
+        LOG_E("importFromEPSG(4326) failed, err_code=%d", outErr);
+        return false;
+    }
+    outRs.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    OGRCoordinateTransformation *poCT = OGRCreateCoordinateTransformation(&inRs, &outRs );
     GeoTransform::Init(poCT, val);
     if (poCT) {
         if (poCT->Transform( 1, val, val + 1)) {
@@ -39,7 +50,7 @@ epsg_convert(int insrs, double* val, char* path) {
         // delete poCT;
     }
     return false;
-} 
+}
 
 extern "C" bool
 wkt_convert(char* wkt, double* val, char* path) {
@@ -99,7 +110,7 @@ transfrom_xyz(double radian_x, double radian_y, double height_min){
     double px = x0 / gamma;
     double py = y0 / gamma;
     double pz = z0 / gamma;
-    
+
     double dx = xn * height_min;
     double dy = yn * height_min;
     double dz = zn * height_min;
@@ -111,13 +122,13 @@ transfrom_xyz(double radian_x, double radian_y, double height_min){
         (x0*east_mat[1] - east_mat[0]*y0)
     };
     double east_normal = std::sqrt(
-        east_mat[0]*east_mat[0] + 
-        east_mat[1]*east_mat[1] + 
+        east_mat[0]*east_mat[0] +
+        east_mat[1]*east_mat[1] +
         east_mat[2]*east_mat[2]
         );
     double north_normal = std::sqrt(
-        north_mat[0]*north_mat[0] + 
-        north_mat[1]*north_mat[1] + 
+        north_mat[0]*north_mat[0] +
+        north_mat[1]*north_mat[1] +
         north_mat[2]*north_mat[2]
         );
 
@@ -197,11 +208,11 @@ write_tileset_box(Transform* trans, Box& box, double geometricError,
 }
 
 bool write_tileset_region(
-    Transform* trans, 
+    Transform* trans,
     Region& region,
     double geometricError,
     const char* b3dm_file,
-    const char* json_file) 
+    const char* json_file)
 {
     std::vector<double> matrix;
     if (trans) {
@@ -279,13 +290,13 @@ write_tileset(double radian_x, double radian_y,
         (x0*east_mat[1] - east_mat[0]*y0)
     };
     double east_normal = std::sqrt(
-        east_mat[0]*east_mat[0] + 
-        east_mat[1]*east_mat[1] + 
+        east_mat[0]*east_mat[0] +
+        east_mat[1]*east_mat[1] +
         east_mat[2]*east_mat[2]
         );
     double north_normal = std::sqrt(
-        north_mat[0]*north_mat[0] + 
-        north_mat[1]*north_mat[1] + 
+        north_mat[0]*north_mat[0] +
+        north_mat[1]*north_mat[1] +
         north_mat[2]*north_mat[2]
         );
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "d5182f703b51d7b258f83f94d936ac03488dcdbe",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": [
+    "osg",
+    "gdal"
+  ]
+}


### PR DESCRIPTION
1. 修改C++构建：使用cmake构建，增加CMakeLists.txt；基于clangd插件和compile_commands.json改进vscode下的C++代码跳转；build.rs中增加cmake调用；
2. 修复OSGB导出时的坐标转换流程，build.rs中增加拷贝proj_lib和gdal_data，https://github.com/fanvanzh/3dtiles/issues/336；
3. 修复Windows下构建的问题(openscenegraph的头文件和Windows.h的兼容问题)，https://github.com/fanvanzh/3dtiles/issues/338；
4. 增加了vscode下的rust调试的配置(.vscode目录下的launch和task文件)

补充说明（构建工具链）：
1. Linux/macOS：仍然使用对应的包管理器安装gdal和osg(openscenegraph)的依赖包
2. Windows: 使用vcpkg作为包管理器
3. 增加CMakeLists.txt，vscode可以使用compile_commands.json便于C++代码头文件跳转(可以使用cmake -S . -B build 生成json文件，C++插件会读取.vscode/c_cpp_properties.json文件里的配置)