### PR TITLE
Make vcpkg cached

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         doNotCache: false
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
+        runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
@@ -36,5 +37,5 @@ jobs:
 
     - name: Build
       run: cargo build -vv --release
-      # env:
-      #   ENABLE_STRICT_CHECKS: 1
+      env:
+        VCPKG_HAS_BEEN_INSTALLED: 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,13 +17,26 @@ jobs:
     - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
+    
+    - name: Install OpenGL related dependencies
+      run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libx11-dev libxrandr-dev libxi-dev libxxf86vm-dev autoconf autoconf-archive automake libtool
+
+    - name: Cache vcpkg tool and installed packages
+      uses: actions/cache@v4
+      id: cache-vcpkg
+      with:
+        path: |
+          ${{ github.workspace }}/vcpkg_installed/
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-installed-
 
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11
       with:
-        doNotCache: false
+        doNotCache: true
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
-        runVcpkgInstall: true
+        runVcpkgInstall: ${{ steps.cache-vcpkg-installed.outputs.cache-hit != 'true' }}
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
@@ -32,9 +45,6 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
-
-    - name: Install OpenGL related dependencies
-      run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libx11-dev libxrandr-dev libxi-dev libxxf86vm-dev autoconf autoconf-archive automake libtool
 
     - name: Build
       run: cargo build -vv --release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,7 @@ jobs:
         runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ github.workspace }}/vcpkg_installed/
         key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-installed-
+          ${{ runner.os }}-vcpkg-
 
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/macOS-arm64.yml
+++ b/.github/workflows/macOS-arm64.yml
@@ -21,12 +21,23 @@ jobs:
     - name: Install automake (including aclocal)
       run: brew install autoconf autoconf-archive automake libtool
 
+    - name: Cache vcpkg tool and installed packages
+      uses: actions/cache@v4
+      id: cache-vcpkg
+      with:
+        path: |
+          ${{ github.workspace }}/vcpkg_installed/
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-installed-
+
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11
       with:
-        doNotCache: false
+        doNotCache: true
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
-        runVcpkgInstall: true
+        runVcpkgInstall: ${{ steps.cache-vcpkg-installed.outputs.cache-hit != 'true' }}
+        runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`, `--allow-unsupported`]'
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed

--- a/.github/workflows/macOS-arm64.yml
+++ b/.github/workflows/macOS-arm64.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         doNotCache: false
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
+        runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
@@ -36,5 +37,5 @@ jobs:
 
     - name: Build
       run: cargo build -vv --release
-      # env:
-      #   ENABLE_STRICT_CHECKS: 1
+      env:
+        VCPKG_HAS_BEEN_INSTALLED: 1

--- a/.github/workflows/macOS-arm64.yml
+++ b/.github/workflows/macOS-arm64.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Install automake (including aclocal)
+      run: brew install autoconf autoconf-archive automake libtool
+
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11
       with:
@@ -26,9 +29,7 @@ jobs:
         runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-
-    - name: Install automake (including aclocal)
-      run: brew install autoconf autoconf-archive automake libtool
+        VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/macOS-arm64.yml
+++ b/.github/workflows/macOS-arm64.yml
@@ -27,9 +27,9 @@ jobs:
       with:
         path: |
           ${{ github.workspace }}/vcpkg_installed/
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        key: ${{ runner.os }}-arm-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-installed-
+          ${{ runner.os }}-arm-vcpkg-
 
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/macOS-intel.yml
+++ b/.github/workflows/macOS-intel.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         doNotCache: false
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
+        runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
@@ -36,5 +37,5 @@ jobs:
 
     - name: Build
       run: cargo build -vv --release
-      # env:
-      #   ENABLE_STRICT_CHECKS: 1
+      env:
+        VCPKG_HAS_BEEN_INSTALLED: 1

--- a/.github/workflows/macOS-intel.yml
+++ b/.github/workflows/macOS-intel.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Install automake (including aclocal)
+      run: brew install autoconf autoconf-archive automake libtool
+
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11
       with:
@@ -26,9 +29,7 @@ jobs:
         runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-
-    - name: Install automake (including aclocal)
-      run: brew install autoconf autoconf-archive automake libtool
+        VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/macOS-intel.yml
+++ b/.github/workflows/macOS-intel.yml
@@ -27,9 +27,9 @@ jobs:
       with:
         path: |
           ${{ github.workspace }}/vcpkg_installed/
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        key: ${{ runner.os }}-x64-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-installed-
+          ${{ runner.os }}-x64-vcpkg-
 
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/macOS-intel.yml
+++ b/.github/workflows/macOS-intel.yml
@@ -21,12 +21,22 @@ jobs:
     - name: Install automake (including aclocal)
       run: brew install autoconf autoconf-archive automake libtool
 
+    - name: Cache vcpkg tool and installed packages
+      uses: actions/cache@v4
+      id: cache-vcpkg
+      with:
+        path: |
+          ${{ github.workspace }}/vcpkg_installed/
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-installed-
+
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11
       with:
-        doNotCache: false
+        doNotCache: true
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
-        runVcpkgInstall: true
+        runVcpkgInstall: ${{ steps.cache-vcpkg-installed.outputs.cache-hit != 'true' }}
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,6 +26,7 @@ jobs:
         runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,12 +18,22 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Cache vcpkg tool and installed packages
+      uses: actions/cache@v4
+      id: cache-vcpkg
+      with:
+        path: |
+          ${{ github.workspace }}/vcpkg_installed/
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-installed-
+
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11
       with:
-        doNotCache: false
+        doNotCache: true
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
-        runVcpkgInstall: true
+        runVcpkgInstall: ${{ steps.cache-vcpkg-installed.outputs.cache-hit != 'true' }}
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
           ${{ github.workspace }}/vcpkg_installed/
         key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-installed-
+          ${{ runner.os }}-vcpkg-
 
     - name: Setup anew (or from cache) vcpkg (and does not build any package)
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         doNotCache: false
         vcpkgGitCommitId: '84bab45d415d22042bd0b9081aea57f362da3f35'
+        runVcpkgInstall: true
       env:
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
@@ -33,5 +34,5 @@ jobs:
 
     - name: Build
       run: cargo build -vv --release
-      # env:
-      #   ENABLE_STRICT_CHECKS: 1
+      env:
+        VCPKG_HAS_BEEN_INSTALLED: 1

--- a/build.rs
+++ b/build.rs
@@ -29,9 +29,82 @@ fn export_compile_commands(out_dir: &Path) {
     }
 }
 
+fn create_dir_symlink() -> std::io::Result<()> {
+    let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("Failed to get CARGO_MANIFEST_DIR environment variable");
+    let root_vcpkg_installed_dir = Path::new(&cargo_manifest_dir).join("vcpkg_installed");
+    if !root_vcpkg_installed_dir.exists() {
+        let err_msg = format!(
+            "root_vcpkg_installed_dir not exists: {}",
+            root_vcpkg_installed_dir.display()
+        );
+        println!("cargo:warning={}", err_msg);
+        return Err(io::Error::new(io::ErrorKind::NotFound, err_msg));
+    }
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let build_vcpkg_installed_dir = Path::new(&out_dir).join("build").join("vcpkg_installed");
+
+    if let Some(parent_build_vcpkg_installed_dir) = build_vcpkg_installed_dir.parent() {
+        fs::create_dir_all(parent_build_vcpkg_installed_dir)?;
+    }
+
+    println!(
+        "cargo:warning=build_vcpkg_installed_dir: {}",
+        build_vcpkg_installed_dir.display()
+    );
+
+    if build_vcpkg_installed_dir.exists() {
+        println!(
+            "cargo:warning=build_vcpkg_installed_dir already exists, so there is no need to create it again.: {:?}",
+            build_vcpkg_installed_dir
+        );
+        return Ok(());
+    }
+
+    #[cfg(target_family = "unix")]
+    {
+        std::os::unix::fs::symlink(root_vcpkg_installed_dir, build_vcpkg_installed_dir)?;
+    }
+
+    #[cfg(target_family = "windows")]
+    {
+        let status = std::process::Command::new("cmd")
+            .args([
+                "/c",
+                "mklink",
+                "/J",
+                &build_vcpkg_installed_dir.to_string_lossy(),
+                &root_vcpkg_installed_dir.to_string_lossy(),
+            ])
+            .status()?;
+
+        if status.success() {
+            println!(
+                "cargo:warning=mklink /J success: {:?} -> {:?}",
+                build_vcpkg_installed_dir, root_vcpkg_installed_dir
+            );
+        } else {
+            let err_msg = format!(
+                "mklink /J failed: {:?} -> {:?}",
+                build_vcpkg_installed_dir, root_vcpkg_installed_dir
+            );
+            println!("cargo:warning={}", err_msg);
+            return Err(io::Error::new(io::ErrorKind::Other, err_msg));
+        }
+    }
+
+    Ok(())
+}
+
 fn build_win_msvc() {
     // Get VCPKG_ROOT environment variable
     let vcpkg_root = std::env::var("VCPKG_ROOT").expect("VCPKG_ROOT environment variable is not set");
+
+    let vcpkg_has_been_installed = env::var("VCPKG_HAS_BEEN_INSTALLED").unwrap_or_default() == "1";
+    if vcpkg_has_been_installed {
+        create_dir_symlink().expect("create_dir_symlink fail");
+    }
 
     // Check if strict mode is enabled via environment variable
     let enable_strict = env::var("ENABLE_STRICT_CHECKS").unwrap_or_default() == "1";
@@ -116,6 +189,11 @@ fn get_target_dir() -> std::path::PathBuf {
 
 fn build_linux_unknown() {
     let vcpkg_root = std::env::var("VCPKG_ROOT").expect("VCPKG_ROOT environment variable is not set");
+
+    let vcpkg_has_been_installed = env::var("VCPKG_HAS_BEEN_INSTALLED").unwrap_or_default() == "1";
+    if vcpkg_has_been_installed {
+        create_dir_symlink().expect("create_dir_symlink fail");
+    }
 
     // Check if strict mode is enabled via environment variable
     let enable_strict = env::var("ENABLE_STRICT_CHECKS").unwrap_or_default() == "1";
@@ -243,6 +321,11 @@ fn build_linux_unknown() {
 
 fn build_macos() {
     let vcpkg_root = std::env::var("VCPKG_ROOT").expect("VCPKG_ROOT environment variable is not set");
+    
+    let vcpkg_has_been_installed = env::var("VCPKG_HAS_BEEN_INSTALLED").unwrap_or_default() == "1";
+    if vcpkg_has_been_installed {
+        create_dir_symlink().expect("create_dir_symlink fail");
+    }
 
     // Check if strict mode is enabled via environment variable
     let enable_strict = env::var("ENABLE_STRICT_CHECKS").unwrap_or_default() == "1";
@@ -377,6 +460,11 @@ fn build_macos() {
 
 fn build_macos_x86_64() {
     let vcpkg_root = std::env::var("VCPKG_ROOT").expect("VCPKG_ROOT environment variable is not set");
+
+    let vcpkg_has_been_installed = env::var("VCPKG_HAS_BEEN_INSTALLED").unwrap_or_default() == "1";
+    if vcpkg_has_been_installed {
+        create_dir_symlink().expect("create_dir_symlink fail");
+    }
 
     // Check if strict mode is enabled via environment variable
     let enable_strict = env::var("ENABLE_STRICT_CHECKS").unwrap_or_default() == "1";
@@ -573,6 +661,7 @@ fn copy_osg_plugins(plugins_dir: &str) {
 }
 
 /// 打印 ./vcpkg_installed 下的目录树，用 cargo:warning 输出，这样能在 cargo build 输出中看到
+#[allow(dead_code)]
 fn print_vcpkg_tree(root: &Path) -> io::Result<()> {
     if !root.exists() {
         println!("cargo:warning=path '{}' does not exist", root.display());


### PR DESCRIPTION
Each time vcpkg is repeatedly built, a lot of time is consumed. Caching dependency builds can shorten the build time